### PR TITLE
Chore/remove mand fields ux templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-brief.yml
+++ b/.github/ISSUE_TEMPLATE/project-brief.yml
@@ -10,7 +10,7 @@ body:
       description: "Describe from the user's perspective. Focus on what’s happening, not solutions."
       placeholder: "Users abandon the appointment form when asked to confirm their NHS number."
     validations:
-      required: true
+      required: false
   - type: textarea
     id: why
     attributes:
@@ -18,7 +18,7 @@ body:
       description: "Explain the impact on users, staff, or service outcomes."
       placeholder: "Confusion at this step increases incomplete submissions and call volume."
     validations:
-      required: true
+      required: false
   - type: dropdown
     id: scope
     attributes:
@@ -30,7 +30,7 @@ body:
         - "A complex multi-step process or transactional journey"
         - "Site wide or service level (a large and wide reaching issue, it's big)"
     validations:
-      required: true
+      required: false
   - type: checkboxes
     id: users
     attributes:
@@ -49,7 +49,7 @@ body:
       label: "Summary goals"
       description: "Concisely list out the main goals for this project."
     validations:
-      required: true
+      required: false
   - type: textarea
     id: business
     attributes:
@@ -82,7 +82,7 @@ body:
         - label: "Yes"
         - label: "No"
     validations:
-      required: true
+      required: false
   - type: textarea
     id: success
     attributes:

--- a/.github/ISSUE_TEMPLATE/ux-action.yml
+++ b/.github/ISSUE_TEMPLATE/ux-action.yml
@@ -9,7 +9,7 @@ body:
       label: "What needs doing?"
       description: "Keep this concise and actionable — a single piece of work."
     validations:
-      required: true
+      required: false
   - type: dropdown
     id: category
     attributes:
@@ -21,7 +21,7 @@ body:
         - "Research"
         - "Documentation"
     validations:
-      required: true
+      required: false
   - type: textarea
     id: notes
     attributes:

--- a/.github/ISSUE_TEMPLATE/ux-activity.yml
+++ b/.github/ISSUE_TEMPLATE/ux-activity.yml
@@ -11,7 +11,7 @@ body:
       description: "What’s the purpose of this task?"
       placeholder: "Validate revised confirmation step with low-vision users."
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: details
@@ -20,7 +20,7 @@ body:
       description: "Describe what will be done, including design or research details as needed."
       placeholder: "Update CSS tokens for focus rings. Test using NVDA and keyboard-only navigation."
     validations:
-      required: true
+      required: false
 
   - type: dropdown
     id: category
@@ -38,7 +38,7 @@ body:
         - "Frontend component"
         - "Other"
     validations:
-      required: true
+      required: false
       
   - type: textarea
     id: notes

--- a/.github/ISSUE_TEMPLATE/ux-problem-statment.yml
+++ b/.github/ISSUE_TEMPLATE/ux-problem-statment.yml
@@ -10,7 +10,7 @@ body:
       description: "Describe from the user's perspective. Focus on what’s happening, not solutions."
       placeholder: "Users abandon the appointment form when asked to confirm their NHS number."
     validations:
-      required: true
+      required: false
   - type: textarea
     id: why
     attributes:
@@ -18,7 +18,7 @@ body:
       description: "Explain the impact on users, staff, or service outcomes."
       placeholder: "Confusion at this step increases incomplete submissions and call volume."
     validations:
-      required: true
+      required: false
   - type: dropdown
     id: scope
     attributes:


### PR DESCRIPTION
Replaced all of the mandatory fields in the UX templates to be optional so that we can create placeholder issues and not need to take ages filling out all the information at once.