### PR TITLE
Add conditional to make local version path work

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -153,12 +153,16 @@ export default function (eleventyConfig) {
 
   eleventyConfig.setLibrary('md', markdownIt({ html: true }).use(anchor))
 
+  // Check if we are running in a GitHub Action environment
+  const isProduction = process.env.GITHUB_ACTIONS === 'true'
+
   return {
     dir: {
       input: 'docs',
       output: 'dist/docs'
     },
-    pathPrefix: "/tel-frontend/",
+    // Only use the prefix if we are in production
+    pathPrefix: isProduction ? '/tel-frontend/' : '/',
     markdownTemplateEngine: 'njk'
   }
 }


### PR DESCRIPTION
When previewing the documentation site locally, the path was expecting the tel-frontend element. I have added a conditional to make it work both locally and on the github io page.