### PR TITLE
Refactor to move installation instructions into docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,72 +12,17 @@ NHS TEL frontend is maintained by staff at NHS England. If you have a question, 
 
 NHS TEL builds directly upon the foundational rules of the [NHS design system](https://service-manual.nhs.uk/design-system). However, because TEL applications require specific user journeys, this repository serves to document and deliver our specialised design components and patterns alongside clear usage guidance.
 
-## Technical installation and setup guide
+## Quick Start & Installation
 
-This library provides extended components built on top of the **NHS.UK Frontend (v10)** framework. Follow these steps to integrate these components into your project pipeline.
+NHS TEL Frontend requires **NHS.UK Frontend v10** as a peer dependency.
 
-### 1. Installation
+For complete step-by-step setup instructions—including configuring build tools (Vite/Webpack), importing styles, and initializing JavaScript—please visit our official guide:
 
-This package requires **NHS.UK Frontend v10** as a peer dependency.
+[**NHS TEL Frontend Installation & Setup Guide**](https://technologyenhancedlearning.github.io/tel-frontend/get-started/installation/)
 
-Install both using npm:
+### Fast Install
+If you just need the packages, you can install them sequentially via npm:
 
 ```bash
 npm install nhsuk-frontend@10
 npm install tel-frontend
-```
-
-### 2. Build tool configuration (Sass load paths)
-
-Because this package references core NHS styles via bare import paths (for example, @import "nhsuk/index";), you must configure your build tool's Sass preprocessor to include the proper node_modules paths.
-
-If you use Vite (vite.config.js)
-```javascript
-export default {
-  css: {
-    preprocessorOptions: {
-      scss: {
-        loadPaths: ['node_modules', 'node_modules/nhsuk-frontend/dist'],
-      },
-    },
-  },
-};
-```
-
-If you use Webpack (webpack.config.js or next.config.js)
-
-Configure your sass-loader options to include the paths:
-```javascript
-{
-  loader: "sass-loader",
-  options: {
-    sassOptions: {
-      includePaths: ['node_modules', 'node_modules/nhsuk-frontend/dist']
-    }
-  }
-}
-```
-
-### 3. Importing styles
-In your application's main Sass stylesheet (for example, styles.scss or app.scss), import the NHS core layout followed by the extension components.
-```
-// 1. Import core NHS.UK Frontend styles
-@import "nhsuk-frontend/dist/nhsuk";
-
-// 2. Import your extension styles
-@import "tel-frontend/dist/tel-frontend/all";
-```
-
-### 4. Initialising JavaScript
-If you are using interactive components that require JavaScript functionality, initialise both packages in your primary JavaScript entry point (for example, main.js or index.js):
-In your application's main Sass stylesheet (for example, styles.scss or app.scss), import the NHS core layout followed by the extension components.
-```
-import { initAll } from 'nhsuk-frontend';
-import { initAll as initTelExtensions } from 'tel-frontend/dist/tel-frontend/all.js';
-
-// Boot them up
-initAll();
-initTelExtensions();
-
-
-```

--- a/docs/get-started/component-structure.md
+++ b/docs/get-started/component-structure.md
@@ -2,7 +2,7 @@
 layout: layouts/get-started.njk
 title: Component structure
 tags: setup
-order: 2
+order: 3
 ---
 
 When building a new component for the TEL design system (or editing an existing one), you will be working inside the `src/components/` directory.

--- a/docs/get-started/documenting-components.md
+++ b/docs/get-started/documenting-components.md
@@ -2,7 +2,7 @@
 layout: layouts/get-started.njk
 title: How to document components
 tags: setup
-order: 3
+order: 4
 ---
 
 This guide explains how to update an existing component page to include UX guidance, research findings and accessibility notes.

--- a/docs/get-started/documenting-components.md
+++ b/docs/get-started/documenting-components.md
@@ -5,7 +5,7 @@ tags: setup
 order: 4
 ---
 
-This guide explains how to update an existing component page to include UX guidance, research findings and accessibility notes.
+This guide explains how to update an existing component page to include UX guidance and research findings.
 
 ## Where to find the files
 

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -1,0 +1,75 @@
+---
+layout: layouts/get-started.njk
+title: Installation
+tags: setup
+order: 1
+---
+
+This library provides extended components built on top of the **NHS.UK Frontend (v10)** framework. Follow these steps to integrate these components into your project pipeline.
+
+### 1. Install packages
+
+This package requires **NHS.UK Frontend v10** as a peer dependency.
+
+Install the packages using npm:
+
+```bash
+npm install nhsuk-frontend@10
+npm install tel-frontend
+```
+
+### 2. Build tool configuration (Sass load paths)
+
+Because this package references core NHS styles via bare import paths (for example, @import "nhsuk/index";), you must configure your build tool's Sass preprocessor to include the proper node_modules paths.
+
+If you use Vite (vite.config.js)
+```javascript
+export default {
+  css: {
+    preprocessorOptions: {
+      scss: {
+        loadPaths: ['node_modules', 'node_modules/nhsuk-frontend/dist'],
+      },
+    },
+  },
+};
+```
+
+If you use Webpack (webpack.config.js or next.config.js)
+
+Configure your sass-loader options to include the paths:
+```javascript
+{
+  loader: "sass-loader",
+  options: {
+    sassOptions: {
+      includePaths: ['node_modules', 'node_modules/nhsuk-frontend/dist']
+    }
+  }
+}
+```
+
+### 3. Importing styles
+In your application's main Sass stylesheet (for example, styles.scss or app.scss), import the NHS core layout followed by the extension components.
+```
+// 1. Import core NHS.UK Frontend styles
+@import "nhsuk-frontend/dist/nhsuk";
+
+// 2. Import your extension styles
+@import "tel-frontend/dist/tel-frontend/all";
+```
+
+### 4. Initialising JavaScript
+If you are using interactive components that require JavaScript functionality, initialise both packages in your primary JavaScript entry point (for example, main.js or index.js):
+In your application's main Sass stylesheet (for example, styles.scss or app.scss), import the NHS core layout followed by the extension components.
+```
+import { initAll } from 'nhsuk-frontend';
+import { initAll as initTelExtensions } from 'tel-frontend/dist/tel-frontend/all.js';
+
+// Boot them up
+initAll();
+initTelExtensions();
+
+
+```
+

--- a/docs/get-started/project-structure.md
+++ b/docs/get-started/project-structure.md
@@ -2,7 +2,7 @@
 layout: layouts/get-started.njk
 title: Project structure
 tags: setup
-order: 1
+order: 2
 ---
 
 This guide provides a high-level overview of how the TEL frontend repository is organised. Understanding this structure will help you know exactly where to add new components, write documentation and configure the build process.


### PR DESCRIPTION
I have moved the technical installation instructions from the readme.md file into the documentation site. It makes more sense to have it here. I had to change the order of the other getting started pages to allow me to insert this installation page in first.