### PR TITLE
Updated code block rendering and formatting of file

### DIFF
--- a/docs/_includes/example.njk
+++ b/docs/_includes/example.njk
@@ -1,107 +1,144 @@
 <div class="tel-example">
   <span class="tel-example__new-window">
-    <a href="{{ href }}" target="_blank">Open this example <span class="nhsuk-u-visually-hidden">({{ title }})</span> in a new tab</a>
+    <a href="{{ href }}" target="_blank">Open this example <span class="nhsuk-u-visually-hidden">({{ title }})</span> in
+      a new tab</a>
   </span>
   {%- if mobile == true %}
   <div class="tel-iframe__container">
-    <div class="tel-iframe__header {%- if mobileHeader == "blue" %} tel-iframe__header--blue{% endif -%}"></div>
+    <div class="tel-iframe__header {%- if mobileHeader == " blue" %} tel-iframe__header--blue{% endif -%}"></div>
     <svg class="ios-notch" viewBox="-40 0 300 31">
-      <path d="M0 1V0h219v1a5 5 0 0 0-5 5v3c0 12.15-9.85 22-22 22H27C14.85 31 5 21.15 5 9V6a5 5 0 0 0-5-5z" fill-rule="evenodd"></path>
+      <path d="M0 1V0h219v1a5 5 0 0 0-5 5v3c0 12.15-9.85 22-22 22H27C14.85 31 5 21.15 5 9V6a5 5 0 0 0-5-5z"
+        fill-rule="evenodd"></path>
     </svg>
-  {% endif -%}
-  <iframe
-    onload="{%- if mobile == true %}{% else %}this.style.height = this.contentWindow.document.documentElement.scrollHeight + 'px';{% endif %}"
-    class="tel-example__frame"
-    scrolling="auto"
-    frameborder="0"
-    height="{%- if mobile == true %}700px{% else %}{{ height }}{% endif %}"
-    src="{{ href }}"
-    title="{{ title }}"
-  ></iframe>
-  {%- if mobile == true %}
+    {% endif -%}
+    <iframe
+      onload="{%- if mobile == true %}{% else %}this.style.height = this.contentWindow.document.documentElement.scrollHeight + 'px';{% endif %}"
+      class="tel-example__frame" scrolling="auto" frameborder="0"
+      height="{%- if mobile == true %}700px{% else %}{{ height }}{% endif %}" src="{{ href }}"
+      title="{{ title }}"></iframe>
+    {%- if mobile == true %}
   </div>
   {% endif -%}
 </div>
 
-{# Tabs - seperate into an include #}
+{# Tabs - separate into an include #}
 <div class="tel-tabs" data-module="tel-tabs">
   {# Tabs list #}
   {% set showNunjucksTab = showNunjucks is not defined or showNunjucks != false %}
   <ul class="tel-tabs__list" role="tablist">
     {%- if showNunjucksTab -%}
-      <li class="tel-tabs__list-item" role="presentation"><a class="tel-tabs__tab nhsuk-link--no-visited-state" href="#html-default-{{ id }}" role="tab" id="tab_html-default-{{ id }}" aria-controls="html-default-{{ id }}">HTML</a></li>
-      <li class="tel-tabs__list-item" role="presentation"><a class="tel-tabs__tab nhsuk-link--no-visited-state" href="#nunjucks-default-{{ id }}" role="tab" id="tab_nunjucks-default-{{ id }}" aria-controls="nunjucks-default-{{ id }}">Nunjucks</a></li>
+    <li class="tel-tabs__list-item" role="presentation"><a class="tel-tabs__tab nhsuk-link--no-visited-state"
+        href="#html-default-{{ id }}" role="tab" id="tab_html-default-{{ id }}"
+        aria-controls="html-default-{{ id }}">HTML</a></li>
+    <li class="tel-tabs__list-item" role="presentation"><a class="tel-tabs__tab nhsuk-link--no-visited-state"
+        href="#nunjucks-default-{{ id }}" role="tab" id="tab_nunjucks-default-{{ id }}"
+        aria-controls="nunjucks-default-{{ id }}">Nunjucks</a></li>
     {%- else -%}
-      <li class="tel-tabs__list-item" role="presentation"><a class="tel-tabs__tab nhsuk-link--no-visited-state" href="#html-default-{{ id }}" role="tab" id="tab_html-default-{{ id }}" aria-controls="html-default-{{ id }}">HTML</a></li>
+    <li class="tel-tabs__list-item" role="presentation"><a class="tel-tabs__tab nhsuk-link--no-visited-state"
+        href="#html-default-{{ id }}" role="tab" id="tab_html-default-{{ id }}"
+        aria-controls="html-default-{{ id }}">HTML</a></li>
     {%- endif -%}
-    {%- if jsCode %}<li class="tel-tabs__list-item" role="presentation"><a class="tel-tabs__tab nhsuk-link--no-visited-state" href="#js-default-{{ id }}" role="tab" id="tab_js-default-{{ id }}" aria-controls="js-default-{{ id }}">JavaScript</a></li>{% endif -%}
-    {%- if figmaLink %}<li class="tel-tabs__list-item" role="presentation"><a class="tel-tabs__tab nhsuk-link--no-visited-state" href="#figma-default-{{ id }}" role="tab" id="tab_figma-default-{{ id }}" aria-controls="figma-default-{{ id }}">Figma</a></li>{% endif -%}
-    {%- if razorLink %}<li class="tel-tabs__list-item" role="presentation"><a class="tel-tabs__tab nhsuk-link--no-visited-state" href="#razor-default-{{ id }}" role="tab" id="tab_razor-default-{{ id }}" aria-controls="razor-default-{{ id }}">Razor component</a></li>{% endif -%}
+    {%- if jsCode %}<li class="tel-tabs__list-item" role="presentation"><a
+        class="tel-tabs__tab nhsuk-link--no-visited-state" href="#js-default-{{ id }}" role="tab"
+        id="tab_js-default-{{ id }}" aria-controls="js-default-{{ id }}">JavaScript</a></li>{% endif -%}
+    {%- if figmaLink %}<li class="tel-tabs__list-item" role="presentation"><a
+        class="tel-tabs__tab nhsuk-link--no-visited-state" href="#figma-default-{{ id }}" role="tab"
+        id="tab_figma-default-{{ id }}" aria-controls="figma-default-{{ id }}">Figma</a></li>{% endif -%}
+    {%- if razorLink %}<li class="tel-tabs__list-item" role="presentation"><a
+        class="tel-tabs__tab nhsuk-link--no-visited-state" href="#razor-default-{{ id }}" role="tab"
+        id="tab_razor-default-{{ id }}" aria-controls="razor-default-{{ id }}">Razor component</a></li>{% endif -%}
   </ul>
 
   {# HTML Tab content #}
-  <div class="tel-tabs__panel tel-tabs__panel--hidden" id="html-default-{{ id }}" role="tabpanel" aria-labelledby="tab_html-default-{{ id }}">
-    <button class="tel-copy__button" data-module="tel-copy" data-clipboard-target="#html-default-{{ id }}-code">Copy code</button>
+  <div class="tel-tabs__panel tel-tabs__panel--hidden" id="html-default-{{ id }}" role="tabpanel"
+    aria-labelledby="tab_html-default-{{ id }}">
+    <button class="tel-copy__button" data-module="tel-copy" data-clipboard-target="#html-default-{{ id }}-code">Copy
+      code</button>
     <div id="html-default-{{ id }}-code">
-      {%- highlight "html" -%}
-        {{ htmlCode | safe }}
-      {%- endhighlight -%}
+      {#
+      CRITICAL WARNING:
+      Do NOT indent the markdown backticks or the variable below.
+      They MUST remain perfectly flush against the left margin.
+      Indenting them will break the global Markdown compiler and shatter the layout.
+      #}
+```html
+{{ htmlCode | safe }}
+```
+
     </div>
   </div>
 
   {# Nunjucks Tab content #}
-  <div class="tel-tabs__panel tel-tabs__panel--hidden" id="nunjucks-default-{{ id }}" role="tabpanel" aria-labelledby="tab_nunjucks-default-{{ id }}">
-
+  <div class="tel-tabs__panel tel-tabs__panel--hidden" id="nunjucks-default-{{ id }}" role="tabpanel"
+    aria-labelledby="tab_nunjucks-default-{{ id }}">
     {%- if arguments -%}
-      <details class="nhsuk-details nhsuk-u-padding-4" data-module="nhsuk-details">
-        <summary class="nhsuk-details__summary">
-          <span class="nhsuk-details__summary-text">
-            Nunjucks macro options
-          </span>
-        </summary>
-        <div class="nhsuk-details__text">
-          <p>Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.</p>
-          <p>Some options are required for the macro to work; these are marked as "Required" in the option description.</p>
-          <p>If you're using Nunjucks macros in production with "html" options, or ones ending with "html", you must sanitise the HTML to protect against <a href="https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting">cross-site scripting exploits</a>.</p>
-          {% if arguments %}
-            {% set macroOptionsPath = "tel/components/" + arguments + "/macro-options.md" %}
-            {% if arguments == "card" %}
-              {% set macroOptionsPath = "tel/components/card/macro-options-card.md" %}
-            {% elif arguments == "card-group" %}
-              {% set macroOptionsPath = "tel/components/card/macro-options-card-group.md" %}
-            {% endif %}
-            <div class="tel-table--scroll">
-              {% include macroOptionsPath ignore missing %}
-            </div>
-          {% endif %}
+    <details class="nhsuk-details nhsuk-u-padding-4" data-module="nhsuk-details">
+      <summary class="nhsuk-details__summary">
+        <span class="nhsuk-details__summary-text">
+          Nunjucks macro options
+        </span>
+      </summary>
+      <div class="nhsuk-details__text">
+        <p>Use options to customise the appearance, content and behaviour of a component when using a macro, for
+          example, changing the text.</p>
+        <p>Some options are required for the macro to work; these are marked as "Required" in the option description.
+        </p>
+        <p>If you're using Nunjucks macros in production with "html" options, or ones ending with "html", you must
+          sanitise the HTML to protect against <a
+            href="https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting">cross-site scripting
+            exploits</a>.</p>
+        {% if arguments %}
+        {% set macroOptionsPath = "tel/components/" + arguments + "/macro-options.md" %}
+        {% if arguments == "card" %}
+        {% set macroOptionsPath = "tel/components/card/macro-options-card.md" %}
+        {% elif arguments == "card-group" %}
+        {% set macroOptionsPath = "tel/components/card/macro-options-card-group.md" %}
+        {% endif %}
+        <div class="tel-table--scroll">
+          {% include macroOptionsPath ignore missing %}
         </div>
-      </details>
+        {% endif %}
+      </div>
+    </details>
     {%- endif -%}
-    <button class="tel-copy__button" data-module="tel-copy" data-clipboard-target="#nunjucks-default-{{ id }}-code">Copy code</button>
+    <button class="tel-copy__button" data-module="tel-copy" data-clipboard-target="#nunjucks-default-{{ id }}-code">Copy
+      code</button>
     <div id="nunjucks-default-{{ id }}-code">
-      {%- highlight "jinja2" -%}
-        {{ nunjucksCode | safe }}
-      {%- endhighlight -%}
+      {#
+      CRITICAL WARNING:
+      Do NOT indent the markdown backticks or the variable below.
+      They MUST remain perfectly flush against the left margin.
+      Indenting them will break the global Markdown compiler and shatter the layout.
+      #}
+```jinja2
+{{ nunjucksCode | safe }}
+```
+
     </div>
   </div>
 
   {# Figma Tab content #}
   {% if figmaLink -%}
-    <div class="tel-tabs__panel nhsuk-u-padding-2 tel-tabs__panel--hidden" id="figma-default-{{ id }}" role="tabpanel" aria-labelledby="tab_figma-default-{{ id }}">
+  <div class="tel-tabs__panel nhsuk-u-padding-2 tel-tabs__panel--hidden" id="figma-default-{{ id }}" role="tabpanel"
+    aria-labelledby="tab_figma-default-{{ id }}">
 
-      To use the component in your design, add the NHS TEL Figma library to your working files, and navigate using the components tab.
+    To use the component in your design, add the NHS TEL Figma library to your working files, and navigate using the
+    components tab.
 
-      <a href="{{ figmaLink }}" class="nhsuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">View component in Figma (opens in a new tab)</a>
-    </div>
+    <a href="{{ figmaLink }}" class="nhsuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">View
+      component in Figma (opens in a new tab)</a>
+  </div>
   {% endif -%}
 
   {# Razor Tab content #}
   {% if razorLink -%}
-    <div class="tel-tabs__panel nhsuk-u-padding-2 tel-tabs__panel--hidden" id="razor-default-{{ id }}" role="tabpanel" aria-labelledby="tab_razor-default-{{ id }}">
+  <div class="tel-tabs__panel nhsuk-u-padding-2 tel-tabs__panel--hidden" id="razor-default-{{ id }}" role="tabpanel"
+    aria-labelledby="tab_razor-default-{{ id }}">
 
-      To use the component in your .net application, install the NHS TEL Razor Component Library and import the component.
+    To use the component in your .net application, install the NHS TEL Razor Component Library and import the component.
 
-      <a href="{{ razorLink }}" class="nhsuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">View component in razor (opens in a new tab)</a>
-    </div>
+    <a href="{{ razorLink }}" class="nhsuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">View
+      component in razor (opens in a new tab)</a>
+  </div>
   {% endif -%}
 </div>


### PR DESCRIPTION
Switched the Nunjucks code block rendering mechanism from Eleventy’s custom {% highlight %} paired shortcode to standard Markdown code triple backticks

The custom shortcode was not formatting the code correctly and was introducing paragraph tags.

The updated code preserves the whitespace and indents so the code appears correctly.

Note the backticked code block cannot be indented or it will break. I have added a comment to remind developers of this important point.

Note I also formatted the file - this has made it look like there are a lot more changes than there actually were. It is just the backticked 2 blocks of code really.

As you can see below, the code now displays with the correct indenting.

<img width="853" height="523" alt="image" src="https://github.com/user-attachments/assets/eb1a7012-786e-4614-9ef5-9691b3070edd" />
